### PR TITLE
#31077 - Input rename field

### DIFF
--- a/components/02-elements/form/input/input.config.js
+++ b/components/02-elements/form/input/input.config.js
@@ -6,7 +6,7 @@ module.exports = {
       attribute: '',
       text: 'Label text',
     },
-    input: {
+    field: {
       attribute: '',
       class: '',
       placeholder: 'First and last name'

--- a/components/02-elements/form/input/input.hbs
+++ b/components/02-elements/form/input/input.hbs
@@ -6,10 +6,10 @@
         {{ label.text }}
     </label>
 
-    <input class="input__field {{ input.class }}"
+    <input class="input__field {{ field.class }}"
            id="input"
            type="text"
-           placeholder="{{ input.placeholder }}"
-           {{{ input.attribute }}}
+           placeholder="{{ field.placeholder }}"
+           {{{ field.attribute }}}
     >
 </div>

--- a/components/03-modules/form/form.config.js
+++ b/components/03-modules/form/form.config.js
@@ -1,7 +1,9 @@
 module.exports = {
   context: {
     input: {
-      placeholder: 'This is placeholder',
+      field: {
+        placeholder: 'This is placeholder'
+      }
     },
     button: {
       tag: 'a',


### PR DESCRIPTION
+ Rename input field called `input` to `field`
+ Edit configs where was `input` syntax to `field`

https://dev.snowdog.pro/issues/31077